### PR TITLE
Explicitly call writer.flush() in spw_connection.cc

### DIFF
--- a/storage/sparrow/api/spw_connection.cc
+++ b/storage/sparrow/api/spw_connection.cc
@@ -295,7 +295,7 @@ RequestGuard spw_Connection::compressAndSendBuffer(Action action, const ByteBuff
 			}
 		}
 
-		// writer.flush is automatically done in its destructor
+		writer.flush();
 
 	} catch ( const SparrowException& e ) {
 		// Remove request from queue.
@@ -372,6 +372,9 @@ RequestGuard spw_Connection::compressAndSendBuffer(Action action, const BufferLi
 				}
 			}
 		}
+
+		writer.flush();
+		
 	} catch ( const SparrowException& e ) {
 		// Remove request from queue.
 		getRequest( request->id(), true );


### PR DESCRIPTION
Ensure writer.flush() is explicitly called after sending data.